### PR TITLE
pivotChildren should only be used for scaling up from minScale, 

### DIFF
--- a/android/src/main/java/com/rnds/DirectedScrollView.java
+++ b/android/src/main/java/com/rnds/DirectedScrollView.java
@@ -154,7 +154,9 @@ public class DirectedScrollView extends ReactViewGroup {
       public boolean onScaleBegin(ScaleGestureDetector detector) {
         float x = detector.getFocusX();
         float y = detector.getFocusY();
-        pivotChildren(x, y);
+        if (scaleFactor == minimumZoomScale) {
+          pivotChildren(x, y);
+        }
         updateChildren();
         return true;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-directed-scrollview",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description":
     "A natively implemented scrollview component which lets you specify different scroll directions for child content.",
   "main": "index.js",


### PR DESCRIPTION
The pivot is only relevant when you are zoomed out and focusing your zoom.